### PR TITLE
Code cleanups and better typing

### DIFF
--- a/app/api/groq/route.ts
+++ b/app/api/groq/route.ts
@@ -1,16 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Groq } from "groq-sdk";
 
-if (!process.env.GROQ_API_KEY) {
-  throw new Error("GROQ_API_KEY is not defined in environment variables");
+const apiKey = process.env.GROQ_API_KEY;
+let groq: Groq | null = null;
+if (apiKey) {
+  groq = new Groq({ apiKey });
+} else {
+  console.error("GROQ_API_KEY is not defined in environment variables");
 }
-
-const groq = new Groq({
-  apiKey: process.env.GROQ_API_KEY,
-});
 
 export async function POST(req: NextRequest) {
   try {
+    if (!groq) {
+      return NextResponse.json({ error: "GROQ API key not configured" }, { status: 500 });
+    }
     const { prompt, language } = await req.json();
     const systemPrompt = language === "es"
       ? "Eres un experto en creación de CVs y asesoría de carrera. Genera contenido profesional y relevante para CVs en español."

--- a/components/cv-preview.tsx
+++ b/components/cv-preview.tsx
@@ -65,7 +65,6 @@ function getLanguage() {
   return 'es';
 }
 
-const lang = getLanguage();
 
 export function CVPreview({ data, language }: { data: CVData, language?: 'es' | 'en' }) {
   const lang = language || 'es';

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,14 +1,11 @@
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/components/LanguageContext"
-import { useRouter } from "next/navigation"
 
 export function Header() {
   const { language, setLanguage } = useLanguage();
-  const router = useRouter();
 
   const navigateToCafecito = () => {
     const url = "https://cafecito.app/lautarotapia";
-    console.log("Intentando navegar a:", url); // Para debug
     window.open(url, "_blank", "noopener,noreferrer");
   };
 

--- a/components/steps/personal-data-step.tsx
+++ b/components/steps/personal-data-step.tsx
@@ -44,10 +44,49 @@ interface Experience {
   description: string
 }
 
+interface Education {
+  uid: string
+  degree: string
+  institution: string
+  graduationYear: string
+}
+
+interface Certification {
+  uid: string
+  name: string
+  institution: string
+  date: string
+  id?: string
+}
+
+interface Language {
+  uid: string
+  language: string
+  level: string
+}
+
+interface CVData {
+  presentation: string
+  fullName: string
+  email: string
+  phone: string
+  city: string
+  country: string
+  links: Link[]
+  objective?: string
+  experiences: Experience[]
+  educations: Education[]
+  certifications: Certification[]
+  languages: Language[]
+  technicalSkills: string
+  showCertifications: boolean
+  professionalTitle?: string
+}
+
 interface PersonalDataStepProps {
-  value: any;
-  onChange: (data: any) => void;
-  jobDescription?: string;
+  value: CVData
+  onChange: (data: CVData) => void
+  jobDescription?: string
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove unused router and debug log from header
- avoid redundant language variable in CV preview
- type personal-data-step props
- fail gracefully when GROQ API key is missing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a56f75788328a2445b564a6444c5